### PR TITLE
Call Filter constructor in UglifyJSFilter

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ UglifyJSFilter.prototype = Object.create(Filter.prototype)
 UglifyJSFilter.prototype.constructor = UglifyJSFilter
 function UglifyJSFilter (inputTree, options) {
   if (!(this instanceof UglifyJSFilter)) return new UglifyJSFilter(inputTree, options)
-  this.inputTree = inputTree
+  Filter.call(this, inputTree, options)
   this.options = options || {}
 }
 


### PR DESCRIPTION
This allows passing in options like targetExtension when using this filter in a Brocfile.
